### PR TITLE
fixes python3 appending byte to str issue

### DIFF
--- a/scripts/nmea_tcp_driver
+++ b/scripts/nmea_tcp_driver
@@ -118,9 +118,9 @@ class ReachSocketHandler:
             if not part or len(part) == 0:
                 self.reconnect_to_device()
                 continue
-            if part != "\n":
-                line += part
-            elif part == "\n":
+            if part.decode() != "\n":
+                line += part.decode()
+            else:
                 break
         return line
 


### PR DESCRIPTION
Explanation:
In comparison to earlier versions, python 3 is treats every string as unicode.
The unicode formatted string can be encoded and stored in bytes,
or decoded back into unicode string and saved in string variables