### PR TITLE
Conform buildfiles to ROS2 Iron

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/reach_ros_node
+script_dir=$base/lib/reach_ros_node
 [install]
-install-scripts=$base/lib/reach_ros_node
+install_scripts=$base/lib/reach_ros_node


### PR DESCRIPTION
A small change such that the build files have lowerdashes, and does not give errors building in ros2 Iron. 
